### PR TITLE
go to definition for expressions

### DIFF
--- a/context.vala
+++ b/context.vala
@@ -19,7 +19,7 @@ class Vls.Context {
     public Vala.CodeContext code_context {
         get {
             if (dirty) {
-                stderr.printf ("dirty context, rebuilding\n");
+                message ("dirty context, rebuilding");
 
                 if (_ctx != null) {
                     // stupid workaround for memory leaks in Vala 0.38

--- a/context.vala
+++ b/context.vala
@@ -30,7 +30,7 @@ class Vls.Context {
                 Vala.CodeContext.push (_ctx);
                 dirty = false;
 
-                string version = "0.38.3"; //Config.libvala_version;
+                string version = "0.40.4"; //Config.libvala_version;
                 string[] parts = version.split(".");
                 assert (parts.length == 3);
                 assert (parts[0] == "0");
@@ -43,7 +43,7 @@ class Vls.Context {
                     _ctx.add_define ("VALA_0_%d".printf (i));
                 }
                 _ctx.target_glib_major = 2;
-                _ctx.target_glib_minor = 38;
+                _ctx.target_glib_minor = 56;
                 for (int i = 16; i <= _ctx.target_glib_minor; i += 2) {
                     _ctx.add_define ("GLIB_2_%d".printf (i));
                 }

--- a/iterator.vala
+++ b/iterator.vala
@@ -1,0 +1,408 @@
+class Vls.FindSymbol : Vala.CodeVisitor {
+    private LanguageServer.Position pos;
+    private Vala.SourceFile file;
+    public Gee.List<Vala.CodeNode> result;
+
+    bool match (Vala.CodeNode node) {
+        var sr = node.source_reference;
+        if (sr == null) {
+            stderr.printf ("node %s has no source reference\n", node.type_name);
+            return false;
+        }
+
+        if (sr.begin.line > sr.end.line) {
+            stderr.printf (@"wtf vala: $(node.type_name): $sr\n");
+            return false;
+        }
+
+        if (sr.begin.line != sr.end.line) {
+            var from = (long)Server.get_string_pos (file.content, sr.begin.line-1, sr.begin.column-1);
+            var to = (long)Server.get_string_pos (file.content, sr.end.line-1, sr.end.column);
+            string contents = file.content [from:to];
+            stderr.printf ("Multiline node: %s: %s", node.type_name, sr.to_string ());
+            stderr.printf ("\n\t%s", contents.replace ("\n", " "));
+            stderr.printf ("\n");
+
+            return false;
+        }
+
+        if (sr.begin.line != pos.line) {
+            stderr.printf ("%s @ %s not on line %u\n", node.type_name, sr.to_string (), pos.line);
+            return false;
+        }
+        if (sr.begin.column <= pos.character && pos.character <= sr.end.column) {
+            stderr.printf ("Got node: %s @ %s\n", node.type_name, sr.to_string ());
+            return true;
+        } else {
+            stderr.printf ("%s @ %s not around char %u\n", node.type_name, sr.to_string (), pos.character);
+            return false;
+        }
+    }
+
+    public FindSymbol (Vala.SourceFile file, LanguageServer.Position pos) {
+        this.pos = pos;
+        this.file = file;
+        result = new Gee.ArrayList<Vala.CodeNode> ();
+        this.visit_source_file (file);
+    }
+
+    public override void visit_source_file (Vala.SourceFile file) {
+        file.accept_children (this);
+    }
+
+    public override void visit_addressof_expression (Vala.AddressofExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_array_creation_expression (Vala.ArrayCreationExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_assignment (Vala.Assignment a) {
+        if (this.match (a))
+            result.add (a);
+        a.accept_children (this);
+    }
+
+    public override void visit_base_access (Vala.BaseAccess expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_binary_expression (Vala.BinaryExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_block (Vala.Block b) {
+        b.accept_children (this);
+    }
+
+    public override void visit_boolean_literal (Vala.BooleanLiteral lit) {
+        if (this.match (lit))
+            result.add (lit);
+        lit.accept_children (this);
+    }
+
+    public override void visit_break_statement (Vala.BreakStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_cast_expression (Vala.CastExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_catch_clause (Vala.CatchClause clause) {
+        if (this.match (clause))
+            result.add (clause);
+        clause.accept_children (this);
+    }
+
+    public override void visit_character_literal (Vala.CharacterLiteral lit) {
+        if (this.match (lit))
+            result.add (lit);
+        lit.accept_children (this);
+    }
+
+    public override void visit_class (Vala.Class cl) {
+        if (this.match (cl))
+            result.add (cl);
+        cl.accept_children (this);
+    }
+
+    public override void visit_conditional_expression (Vala.ConditionalExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_constant (Vala.Constant c) {
+        if (this.match (c))
+            result.add (c);
+        c.accept_children (this);
+    }
+
+    public override void visit_constructor (Vala.Constructor c) {
+        if (this.match (c))
+            result.add (c);
+        c.accept_children (this);
+    }
+
+    public override void visit_continue_statement (Vala.ContinueStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_creation_method (Vala.CreationMethod m) {
+        if (this.match (m))
+            result.add (m);
+        m.accept_children (this);
+    }
+
+    public override void visit_declaration_statement (Vala.DeclarationStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_delegate (Vala.Delegate cb) {
+        if (this.match (cb))
+            result.add (cb);
+        cb.accept_children (this);
+    }
+
+    public override void visit_delete_statement (Vala.DeleteStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_do_statement (Vala.DoStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_element_access (Vala.ElementAccess expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_empty_statement (Vala.EmptyStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_enum (Vala.Enum en) {
+        if (this.match (en))
+            result.add (en);
+        en.accept_children (this);
+    }
+
+    public override void visit_error_domain (Vala.ErrorDomain edomain) {
+        if (this.match (edomain))
+            result.add (edomain);
+        edomain.accept_children (this);
+    }
+
+    public override void visit_expression_statement (Vala.ExpressionStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_field (Vala.Field f) {
+        if (this.match (f))
+            result.add (f);
+        f.accept_children (this);
+    }
+
+    public override void visit_for_statement (Vala.ForStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_foreach_statement (Vala.ForeachStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_if_statement (Vala.IfStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_initializer_list (Vala.InitializerList list) {
+        if (this.match (list))
+            result.add (list);
+        list.accept_children (this);
+    }
+
+    public override void visit_integer_literal (Vala.IntegerLiteral lit) {
+        if (this.match (lit))
+            result.add (lit);
+        lit.accept_children (this);
+    }
+
+    public override void visit_interface (Vala.Interface iface) {
+        if (this.match (iface))
+            result.add (iface);
+        iface.accept_children (this);
+    }
+
+    public override void visit_lambda_expression (Vala.LambdaExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_local_variable (Vala.LocalVariable local) {
+        if (this.match (local))
+            result.add (local);
+        local.accept_children (this);
+    }
+
+    public override void visit_lock_statement (Vala.LockStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_loop (Vala.Loop stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_member_access (Vala.MemberAccess expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_method (Vala.Method m) {
+        if (this.match (m))
+            result.add (m);
+        m.accept_children (this);
+    }
+
+    public override void visit_method_call (Vala.MethodCall expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_namespace (Vala.Namespace ns) {
+        if (this.match (ns))
+            result.add (ns);
+        ns.accept_children (this);
+    }
+
+    public override void visit_null_literal (Vala.NullLiteral lit) {
+        if (this.match (lit))
+            result.add (lit);
+        lit.accept_children (this);
+    }
+
+    public override void visit_object_creation_expression (Vala.ObjectCreationExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_pointer_indirection (Vala.PointerIndirection expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_postfix_expression (Vala.PostfixExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_property (Vala.Property prop) {
+        if (this.match (prop))
+            result.add (prop);
+        prop.accept_children (this);
+    }
+
+    public override void visit_real_literal (Vala.RealLiteral lit) {
+        if (this.match (lit))
+            result.add (lit);
+        lit.accept_children (this);
+    }
+
+    public override void visit_reference_transfer_expression (Vala.ReferenceTransferExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_return_statement (Vala.ReturnStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_signal (Vala.Signal sig) {
+        if (this.match (sig))
+            result.add (sig);
+        sig.accept_children (this);
+    }
+
+    public override void visit_sizeof_expression (Vala.SizeofExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_slice_expression (Vala.SliceExpression expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+
+    public override void visit_string_literal (Vala.StringLiteral lit) {
+        if (this.match (lit))
+            result.add (lit);
+        lit.accept_children (this);
+    }
+
+    public override void visit_struct (Vala.Struct st) {
+        if (this.match (st))
+            result.add (st);
+        st.accept_children (this);
+    }
+
+    public override void visit_switch_label (Vala.SwitchLabel label) {
+        if (this.match (label))
+            result.add (label);
+        label.accept_children (this);
+    }
+
+    public override void visit_switch_section (Vala.SwitchSection section) {
+        if (this.match (section))
+            result.add (section);
+        section.accept_children (this);
+    }
+
+    public override void visit_switch_statement (Vala.SwitchStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_throw_statement (Vala.ThrowStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_try_statement (Vala.TryStatement stmt) {
+        if (this.match (stmt))
+            result.add (stmt);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_type_check (Vala.TypeCheck expr) {
+        if (this.match (expr))
+            result.add (expr);
+        expr.accept_children (this);
+    }
+}

--- a/iterator.vala
+++ b/iterator.vala
@@ -16,25 +16,25 @@ class Vls.FindSymbol : Vala.CodeVisitor {
         }
 
         if (sr.begin.line != sr.end.line) {
-            var from = (long)Server.get_string_pos (file.content, sr.begin.line-1, sr.begin.column-1);
-            var to = (long)Server.get_string_pos (file.content, sr.end.line-1, sr.end.column);
-            string contents = file.content [from:to];
-            stderr.printf ("Multiline node: %s: %s", node.type_name, sr.to_string ());
-            stderr.printf ("\n\t%s", contents.replace ("\n", " "));
-            stderr.printf ("\n");
+            //  var from = (long)Server.get_string_pos (file.content, sr.begin.line-1, sr.begin.column-1);
+            //  var to = (long)Server.get_string_pos (file.content, sr.end.line-1, sr.end.column);
+            //  string contents = file.content [from:to];
+            //  stderr.printf ("Multiline node: %s: %s", node.type_name, sr.to_string ());
+            //  stderr.printf ("\n\t%s", contents.replace ("\n", " "));
+            //  stderr.printf ("\n");
 
             return false;
         }
 
         if (sr.begin.line != pos.line) {
-            stderr.printf ("%s @ %s not on line %u\n", node.type_name, sr.to_string (), pos.line);
+            //  stderr.printf ("%s @ %s not on line %u\n", node.type_name, sr.to_string (), pos.line);
             return false;
         }
         if (sr.begin.column <= pos.character && pos.character <= sr.end.column) {
-            stderr.printf ("Got node: %s @ %s\n", node.type_name, sr.to_string ());
+            message ("Got node: %s (%s) @ %s", node.type_name, node.to_string (), sr.to_string ());
             return true;
         } else {
-            stderr.printf ("%s @ %s not around char %u\n", node.type_name, sr.to_string (), pos.character);
+            //  message ("%s @ %s not around char %u\n", node.type_name, sr.to_string (), pos.character);
             return false;
         }
     }

--- a/iterator.vala
+++ b/iterator.vala
@@ -6,12 +6,12 @@ class Vls.FindSymbol : Vala.CodeVisitor {
     bool match (Vala.CodeNode node) {
         var sr = node.source_reference;
         if (sr == null) {
-            stderr.printf ("node %s has no source reference\n", node.type_name);
+            message ("node %s has no source reference", node.type_name);
             return false;
         }
 
         if (sr.begin.line > sr.end.line) {
-            stderr.printf (@"wtf vala: $(node.type_name): $sr\n");
+            warning (@"wtf vala: $(node.type_name): $sr");
             return false;
         }
 
@@ -27,18 +27,20 @@ class Vls.FindSymbol : Vala.CodeVisitor {
         }
 
         if (sr.begin.line != pos.line) {
-            //  stderr.printf ("%s @ %s not on line %u\n", node.type_name, sr.to_string (), pos.line);
             return false;
         }
         if (sr.begin.column <= pos.character && pos.character <= sr.end.column) {
             message ("Got node: %s (%s) @ %s", node.type_name, node.to_string (), sr.to_string ());
             return true;
         } else {
-            //  message ("%s @ %s not around char %u\n", node.type_name, sr.to_string (), pos.character);
             return false;
         }
     }
 
+    /*
+     * TODO: are children of a CodeNode guaranteed to have a source_reference within the parent?
+     * if so, this can be much faster
+     */
     public FindSymbol (Vala.SourceFile file, LanguageServer.Position pos) {
         this.pos = pos;
         this.file = file;

--- a/main.vala
+++ b/main.vala
@@ -695,6 +695,10 @@ class Vls.Server {
             log.printf ("Got node: %s @ %s = %s\n", best.type_name, sr.to_string(), contents);
         }
 
+        if (best is Vala.MemberAccess) {
+            best = ((Vala.MemberAccess)best).symbol_reference;
+        }
+
         string uri = null;
         foreach (var sourcefile in ctx.get_source_files ()) {
             if (best.source_reference.file == sourcefile.file) {
@@ -704,6 +708,7 @@ class Vls.Server {
         }
         if (uri == null) {
             log.printf ("error: couldn't find source file for %s\n", best.source_reference.file.filename);
+            client.reply (id, null);
         }
 
         client.reply (id, object_to_variant (new LanguageServer.Location () {

--- a/main.vala
+++ b/main.vala
@@ -709,6 +709,7 @@ class Vls.Server {
         if (uri == null) {
             log.printf ("error: couldn't find source file for %s\n", best.source_reference.file.filename);
             client.reply (id, null);
+            return;
         }
 
         client.reply (id, object_to_variant (new LanguageServer.Location () {

--- a/main.vala
+++ b/main.vala
@@ -499,6 +499,8 @@ class Vls.Server {
             }
 
             ctx.add_source_file (doc);
+        } else {
+            ctx.get_source_file (uri).file.content = fileContents;
         }
 
         // compile everything if context is dirty

--- a/main.vala
+++ b/main.vala
@@ -83,9 +83,10 @@ class Vls.Server {
 
         server.add_handler ("initialize", this.initialize);
         server.add_handler ("shutdown", this.shutdown);
-        notif_handlers["textDocument/didOpen"] = textDocumentDidOpen;
-        notif_handlers["textDocument/didChange"] = textDocumentDidChange;
-        notif_handlers["exit"] = exit;
+        notif_handlers["exit"] = this.exit;
+
+        notif_handlers["textDocument/didOpen"] = this.textDocumentDidOpen;
+        notif_handlers["textDocument/didChange"] = this.textDocumentDidChange;
 
         log.printf ("Finished constructing\n");
     }

--- a/main.vala
+++ b/main.vala
@@ -731,13 +731,15 @@ class Vls.Server {
             message ("Got node: %s @ %s = %s", best.type_name, sr.to_string(), contents);
         }
 
-        if (best is Vala.MemberAccess) {
-            var b = (Vala.MemberAccess)best;
-            message ("best (%p) is a MemberAccess", best);
+        if (best is Vala.Expression) {
+            var b = (Vala.Expression)best;
+            message ("best (%p) is a Expression", best);
             if (b.symbol_reference != null) {
                 best = b.symbol_reference;
                 message ("best is now the symbol_referenece => %p", best);
             }
+        } else {
+            client.reply (id, null);
         }
 
         /*

--- a/main.vala
+++ b/main.vala
@@ -731,7 +731,7 @@ class Vls.Server {
             message ("Got node: %s @ %s = %s", best.type_name, sr.to_string(), contents);
         }
 
-        if (best is Vala.Expression) {
+        if (best is Vala.Expression && !(best is Vala.Literal)) {
             var b = (Vala.Expression)best;
             message ("best (%p) is a Expression", best);
             if (b.symbol_reference != null) {
@@ -740,6 +740,7 @@ class Vls.Server {
             }
         } else {
             client.reply (id, null);
+            return;
         }
 
         /*

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ src = files([
     'protocol.vala',
     'reporter.vala',
     'context.vala',
+    'iterator.vala',
     'vala038_workarounds.vala',
 ])
 

--- a/protocol.vala
+++ b/protocol.vala
@@ -54,6 +54,13 @@ class LanguageServer.Position : Object {
 	 * line length.
 	 */
 	public uint character { get; set; default = -1; }
+
+	public LanguageServer.Position to_libvala () {
+		return new Position () {
+			line = this.line + 1,
+			character = this.character
+		};
+	}
 }
 
 class LanguageServer.Range : Object {
@@ -124,4 +131,18 @@ enum LanguageServer.MessageType {
 	 * A log message.
 	 */
 	Log = 4
+}
+
+class LanguageServer.TextDocumentIdentifier : Object {
+	public string uri { get; set; }
+}
+
+class LanguageServer.TextDocumentPositionParams : Object {
+	public TextDocumentIdentifier textDocument { get; set; }
+	public Position position { get; set; }
+}
+
+class LanguageServer.Location : Object {
+	public string uri { get; set; }
+	public Range range { get; set; }
 }


### PR DESCRIPTION
- Switching to GLib logging functions fixes buffering & stderr weirdness which causes log messages to become out of order.