### PR TITLE
build and test on windows with msys2 support.

### DIFF
--- a/context.vala
+++ b/context.vala
@@ -42,9 +42,9 @@ class Vls.Context {
                 for (int i = 2; i <= minor; i += 2) {
                     _ctx.add_define ("VALA_0_%d".printf (i));
                 }
-                _ctx.target_glib_major = 2;
-                _ctx.target_glib_minor = 56;
-                for (int i = 16; i <= _ctx.target_glib_minor; i += 2) {
+                
+                int target_glib_minor = 56;
+                for (int i = 16; i <= target_glib_minor; i += 2) {
                     _ctx.add_define ("GLIB_2_%d".printf (i));
                 }
                 foreach (var define in _defines)

--- a/main.vala
+++ b/main.vala
@@ -44,50 +44,6 @@ class Vls.TextDocument : Object {
     }
 }
 
-public class InputStreamFromFileStream
-	: InputStream
-{
-	private unowned FileStream? target;
-
-	public InputStreamFromFileStream(FileStream fs)
-	{
-		target = fs;
-	}
-
-	public override bool close(Cancellable? cancellable = null) throws IOError
-	{
-		target = null;
-		return true;
-	}
-
-	public override ssize_t read(uint8[] buffer, Cancellable? cancellable = null) throws IOError
-	{
-		return (ssize_t)target.read(buffer, 1);
-	}
-}
-
-public class OutputStreamFromFileStream
-	: OutputStream
-{
-	private unowned FileStream? target;
-
-	public OutputStreamFromFileStream(FileStream fs)
-	{
-		target = fs;
-	}
-
-	public override bool close(Cancellable? cancellable = null) throws IOError
-	{
-		target = null;
-		return true;
-	}
-
-	public override ssize_t write(uint8[] buffer, Cancellable? cancellable = null) throws IOError
-	{
-		return (ssize_t)target.write(buffer, 1);
-	}
-}
-
 class Vls.Server {
     Jsonrpc.Server server;
     MainLoop loop;
@@ -124,8 +80,13 @@ class Vls.Server {
         this.ctx = new Vls.Context ();
 
         this.server = new Jsonrpc.Server ();
-        var _stdin = new InputStreamFromFileStream(stdin);
-        var _stdout = new OutputStreamFromFileStream(stdout);
+    #if WINDOWS
+        var _stdin = new Win32InputStream(Win.GetFileHandle(new_stdin_fd), false);
+        var _stdout = new Win32OutputStream(Win.GetFileHandle(new_stdout_fd), false);
+    #else
+        var _stdin = new UnixInputStream(new_stdin_fd, false);
+        var _stdout = new UnixOutputStream(new_stdout_fd, false);
+    #endif
         server.accept_io_stream (new SimpleIOStream (_stdin, _stdout));
 
         notif_handlers = new HashTable <string, NotificationHandler> (str_hash, str_equal);

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,6 @@ libvala = dependency('libvala-@0@'.format(libvala_version))
 deps = [
     dependency('glib-2.0'),
     dependency('gobject-2.0'),
-    dependency('gio-unix-2.0'),
     dependency('gee-0.8'),
     dependency('jsonrpc-glib-1.0'),
     libvala,

--- a/meson.build
+++ b/meson.build
@@ -1,15 +1,28 @@
 project('vala-language-server', 'vala', 'c')
 
+add_project_arguments(['--vapidir', join_paths(meson.source_root(), 'vapi')],
+            language: 'vala')
+
 valac = meson.get_compiler('vala')
 libvala_version = run_command(valac, '--api-version').stdout().strip()
 
 libvala = dependency('libvala-@0@'.format(libvala_version))
+
+os_type = host_machine.system()
+if os_type == 'windows'
+    io_vapi = meson.get_compiler('vala').find_library('win32io', dirs: join_paths(meson.source_root(), 'vapi'))    
+    io_dep = dependency('gio-windows-2.0')
+    io_dep = declare_dependency(dependencies: [io_dep, io_vapi])
+else
+    io_dep = dependency('gio-unix-2.0')
+endif
 
 deps = [
     dependency('glib-2.0'),
     dependency('gobject-2.0'),
     dependency('gee-0.8'),
     dependency('jsonrpc-glib-1.0'),
+    io_dep,
     libvala,
 ]
 
@@ -32,5 +45,5 @@ src = files([
 executable('vala-language-server',
            dependencies: deps,
            sources: [src, conf_file],
-           vala_args: ['--pkg=posix', '--enable-gobject-tracing'],
+           vala_args: ['-D', os_type.to_upper(), '--pkg=posix', '--enable-gobject-tracing'],
            install: true)

--- a/vapi/win32io.vapi
+++ b/vapi/win32io.vapi
@@ -1,0 +1,6 @@
+[CCode (cheader_filename="io.h", lower_case_cprefix = "")]
+namespace Win
+{
+    [CCode (cname = "_get_osfhandle")]
+    void* GetFileHandle(uint fd);
+}


### PR DESCRIPTION
It is not necessary using stdin and stdout file no.
Wrap the file stream into input stream and output stream is a portable solution.