### PR TITLE
Fixes to run in GNOME Builder nightly

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,11 +7,13 @@ project('vala-language-server', 'vala', 'c',
 )
 
 valac = meson.get_compiler('vala')
-# libvala_version = run_command(valac, '--api-version').stdout().strip()
-# 
-# libvala = dependency('libvala-@0@'.format(libvala_version))
+libvala_version = run_command(valac, '--api-version').stdout().strip()
+if not libvala_version.version_compare('>=0.48' )
+  error('libvala needs to be 0.48 or above')
+endif
 
-libvala = dependency('libvala-0.48')
+libvala = dependency('libvala-@0@'.format(libvala_version))
+
 libgobject_dep = dependency('gobject-2.0')
 libjsonrpc_glib_dep = dependency('jsonrpc-glib-1.0', version: '>= 3.28')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('parse_system_girs', type: 'boolean', value: true, description: 'Parse system GIRs for symbol documentation')
 option('active_parameter', type: 'boolean', value: false, description: 'Support activeParameter in signatureHelp')
 option('debug_mem', type: 'boolean', value: false, description: 'Debug memory usage')
+option('builder_abi', type: 'string', value: '3.36', description: 'Builder ABI version')

--- a/plugins/gnome-builder/meson.build
+++ b/plugins/gnome-builder/meson.build
@@ -1,6 +1,13 @@
+conf = configuration_data()
+conf.set('BUILDER_ABI', get_option('builder_abi'))
+configure_file(
+  input: 'vala_langserv.plugin.in',
+  output: 'vala_langserv.plugin',
+  configuration: conf,
+  install_dir: get_option('prefix') / get_option('libdir') / 'gnome-builder' / 'plugins'
+)
 install_data(
   files(
-    'vala_langserv.plugin',
     'vala_langserv.py'
   ),
   install_dir: get_option('prefix') / get_option('libdir') / 'gnome-builder' / 'plugins'

--- a/plugins/gnome-builder/vala_langserv.plugin.in
+++ b/plugins/gnome-builder/vala_langserv.plugin.in
@@ -13,4 +13,4 @@ X-Highlighter-Languages=vala
 X-Hover-Provider-Languages=vala
 X-Rename-Provider-Languages=vala
 X-Symbol-Resolver-Languages=vala
-X-Builder-ABI=3.36
+X-Builder-ABI=@BUILDER_ABI@


### PR DESCRIPTION
- Allow libvala to be 0.48 and above
- Allow to override Builder ABI 3.36 (master is right now 3.37)