### PR TITLE
Revert "Don't set CodeContext.profile" (#92)

### DIFF
--- a/src/girdocumentation.vala
+++ b/src/girdocumentation.vala
@@ -25,7 +25,12 @@ class Vls.GirDocumentation {
         context = new Vala.CodeContext ();
         context.report = new Sink ();
         Vala.CodeContext.push (context);
+#if VALA_0_50
+        context.set_target_profile (Vala.Profile.GOBJECT, false);
+#else
+        context.profile = Vala.Profile.GOBJECT;
         context.add_define ("GOBJECT");
+#endif
 
         // add packages
         add_gir ("GLib-2.0");

--- a/src/projects/compilation.vala
+++ b/src/projects/compilation.vala
@@ -184,6 +184,12 @@ class Vls.Compilation : BuildTarget {
             gresources_directories = _gresources_dirs.to_array ()
         };
 
+#if VALA_0_50
+        code_context.set_target_profile (_profile, false);
+#else
+        code_context.profile = _profile;
+#endif
+
         // Vala compiler bug requires us to initialize things this way instead of
         // the alternative above
         code_context.report = new Reporter (_fatal_warnings);


### PR DESCRIPTION
This reverts commit 877f6cf9d4dc38f85f981a3a902b8bd118fd38dd.

Set the profile, but do it with `set_target_profile()` instead if
building with Vala 0.50

Closes #92 