### PR TITLE
elementaryOS support

### DIFF
--- a/src/main.vala
+++ b/src/main.vala
@@ -302,7 +302,9 @@ class Vls.Server : Object {
             try {
                 project = new MesonProject (root_path, cancellable);
             } catch (Error e) {
-                showMessage (client, @"Failed to initialize Meson project - $(e.message)", MessageType.Error);
+                if (!(e is ProjectError.VERSION_UNSUPPORTED)) {
+                    showMessage (client, @"Failed to initialize Meson project - $(e.message)", MessageType.Error);
+                }
                 project = new DefaultProject (root_path);       // fallback
             }
         } else {

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,7 @@ vls_src = files([
   'list_symbols.vala',
   'projects/buildtarget.vala',
   'projects/buildtask.vala',
+  'projects/ccproject.vala',
   'projects/compilation.vala',
   'projects/defaultproject.vala',
   'projects/mesonproject.vala',

--- a/src/projects/ccproject.vala
+++ b/src/projects/ccproject.vala
@@ -1,0 +1,60 @@
+/**
+ * A backend for `compile_commands.json` files. 
+ */
+class Vls.CcProject : Project {
+    private string root_path;
+    private string build_dir;
+    private File cc_json_file;
+
+    public override bool reconfigure_if_stale (Cancellable? cancellable = null) throws Error {
+        debug ("CcProject: configuring in build dir %s ...", build_dir);
+
+        var parser = new Json.Parser.immutable_new ();
+        parser.load_from_stream (cc_json_file.read (cancellable), cancellable);
+        Json.Node? cc_json_root = parser.get_root ();
+
+        if (cc_json_root == null)
+            throw new ProjectError.INTROSPECTION (@"JSON root is null. Bailing out!");
+
+        // iterate over all compile commands
+        int i = -1;
+        foreach (Json.Node cc_node in cc_json_root.get_array ().get_elements ()) {
+            i++;
+            if (cc_node.get_node_type () != Json.NodeType.OBJECT)
+                throw new ProjectError.INTROSPECTION (@"JSON node is not an object. Bailing out!");
+            var cc = Json.gobject_deserialize (typeof (CompileCommand), cc_node) as CompileCommand?;
+            if (cc == null)
+                throw new ProjectError.INTROSPECTION (@"JSON node is null. Bailing out!");
+
+            if (cc.command.length > 0 && cc.command[0].contains ("valac"))
+                build_targets.add (new Compilation (cc.directory, cc.file ?? @"CC#$i", @"CC#$i", i,
+                                                    cc.command[0:1], cc.command[1:cc.command.length],
+                                                    new string[]{}, new string[]{}));
+            else
+                build_targets.add (new BuildTask (cc.directory, cc.file ?? @"CC#$i", @"CC#$i", i,
+                                                  cc.command[0:1], cc.command[1:cc.command.length], 
+                                                  new string[]{}, new string[]{},
+                                                  new string[]{}, "unknown"));
+        }
+
+        analyze_build_targets (cancellable);
+
+        return true;
+    }
+
+    public CcProject (string root_path, string cc_location, Cancellable? cancellable = null) throws Error {
+        var root_dir = File.new_for_path (root_path);
+        var cc_json_file = File.new_for_commandline_arg_and_cwd (cc_location, root_path);
+        string? relative_path = root_dir.get_relative_path (cc_json_file);
+
+        if (relative_path == null) {
+            throw new ProjectError.INTROSPECTION (@"$cc_location is not relative to project root");
+        }
+
+        this.root_path = root_path;
+        this.build_dir = cc_json_file.get_parent ().get_path ();
+        this.cc_json_file = cc_json_file;
+
+        reconfigure_if_stale (cancellable);
+    }
+}

--- a/src/projects/compilation.vala
+++ b/src/projects/compilation.vala
@@ -74,6 +74,7 @@ class Vls.Compilation : BuildTarget {
         string? flag_name, arg_value;           // --<flag_name>[=<arg_value>]
 
         // because we rely on --directory for determining the location of output files
+        // because we rely on --basedir (if defined) for determining the location of input files
         for (int arg_i = -1; (arg_i = Util.iterate_valac_args (args, out flag_name, out arg_value, arg_i)) < args.length;) {
             if (flag_name == "directory") {
                 if (arg_value == null) {
@@ -136,7 +137,7 @@ class Vls.Compilation : BuildTarget {
                 if (arg_value == null) {
                     warning ("Compilation(%s) failed to parse argument #%d (%s)", id, arg_i, args[arg_i]);
                 } else if (Util.arg_is_vala_file (arg_value)) {
-                    var file_from_arg = File.new_for_path (Util.realpath (arg_value, _directory));
+                    var file_from_arg = File.new_for_path (Util.realpath (arg_value, build_dir));
                     if (build_dir_file.get_relative_path (file_from_arg) != null)
                         _generated_sources.add (file_from_arg);
                     input.add (file_from_arg);
@@ -147,11 +148,11 @@ class Vls.Compilation : BuildTarget {
         }
 
         foreach (string source in sources) {
-            input.add (File.new_for_path (Util.realpath (source, _directory)));
+            input.add (File.new_for_path (Util.realpath (source, build_dir)));
         }
 
         foreach (string generated_source in generated_sources) {
-            var generated_source_file = File.new_for_path (Util.realpath (generated_source, _directory));
+            var generated_source_file = File.new_for_path (Util.realpath (generated_source, build_dir));
             _generated_sources.add (generated_source_file);
             input.add (generated_source_file);
         }

--- a/src/projects/project.vala
+++ b/src/projects/project.vala
@@ -291,6 +291,11 @@ abstract class Vls.Project : Object {
 
 errordomain Vls.ProjectError {
     /**
+     * Project backend has unsupported version.
+     */
+    VERSION_UNSUPPORTED,
+
+    /**
      * Generic error during project introspection.
      */
     INTROSPECTION,

--- a/src/projects/project.vala
+++ b/src/projects/project.vala
@@ -21,6 +21,10 @@ abstract class Vls.Project : Object {
      * built.
      */
     protected void analyze_build_targets (Cancellable? cancellable = null) throws Error {
+        // first, check that at least one target is a Compilation
+        if (!build_targets.any_match (t => t is Compilation))
+            throw new ProjectError.CONFIGURATION (@"project has no Vala targets");
+
         // there may be multiple consumers of a file
         var consumers_of = new HashMap<File, HashSet<BuildTarget>> (Util.file_hash, Util.file_equal);
         // there can only be one producer for a file

--- a/src/util.vala
+++ b/src/util.vala
@@ -39,7 +39,7 @@ namespace Vls.Util {
         MatchInfo match_info;
         string[] args = {};
 
-        if (/(?(?<=')((\\\\|[^'\\]|\\')*(?='))|((?!')((?!\\ )(\\\\|\S)|\\ ))+)/.match (str, 0, out match_info)) {
+        if (/(?(?<=')((\\\\|[^'\\\s]|\\')(\\\\|[^'\\]|\\')*(?='))|((?!')((?!\\ )(\\\\|\S)|\\ ))+)/.match (str, 0, out match_info)) {
             while (match_info.matches ()) {
                 args += match_info.fetch (0);
                 match_info.next ();

--- a/src/util.vala
+++ b/src/util.vala
@@ -311,4 +311,50 @@ namespace Vls.Util {
 
         return matching_sym;
     }
+
+
+    /**
+     * (stolen from VersionAttribute.cmp_versions in `vala/valaversionattribute.vala`)
+     * A simple version comparison function.
+     *
+     * @param v1str a version number
+     * @param v2str a version number
+     * @return an integer less than, equal to, or greater than zero, if v1str is <, == or > than v2str
+     * @see GLib.CompareFunc
+     */
+    public static int compare_versions (string v1str, string v2str) {
+        string[] v1arr = v1str.split (".");
+        string[] v2arr = v2str.split (".");
+        int i = 0;
+
+        while (v1arr[i] != null && v2arr[i] != null) {
+            int v1num = int.parse (v1arr[i]);
+            int v2num = int.parse (v2arr[i]);
+
+            if (v1num < 0 || v2num < 0) {
+                // invalid format
+                return 0;
+            }
+
+            if (v1num > v2num) {
+                return 1;
+            }
+
+            if (v1num < v2num) {
+                return -1;
+            }
+
+            i++;
+        }
+
+        if (v1arr[i] != null && v2arr[i] == null) {
+            return 1;
+        }
+
+        if (v1arr[i] == null && v2arr[i] != null) {
+            return -1;
+        }
+
+        return 0;
+    }
 }


### PR DESCRIPTION
These changes make VLS work on the latest version of elementaryOS, which causes problems for project management because it has an older version of Meson (< 0.50.0). 

The major improvement here is support for `compile_commands.json` with a new backend, `CcProject`, which we use when a Meson project is unavailable.