### PR TITLE
Rename support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ We recommend using VSCode with the [Vala plugin](https://marketplace.visualstudi
         - this feature may be a bit unstable. If it breaks things, use `meson -Dparse_system_girs=false` to disable
 - [x] search for symbols in workspace
 - [x] highlight active symbol in document
+- [x] rename symbols
 - [ ] snippets
 - [ ] code actions
 - [ ] workspaces

--- a/src/codehelp/codehelp.vala
+++ b/src/codehelp/codehelp.vala
@@ -468,7 +468,7 @@ namespace Vls.CodeHelp {
                                               string? override_name = null, bool show_initializers = true) {
         if (data_type == null && sym == null)
             return null;
-        if (data_type == null || sym != null && data_type.symbol == sym) {
+        if (data_type == null || sym != null && SymbolReferences.get_symbol_data_type_refers_to (data_type) == sym) {
             if (sym is Vala.Namespace)
                 return "namespace " + get_symbol_name_representation(sym, scope);
             else if (sym is Vala.Callable) {
@@ -567,6 +567,14 @@ namespace Vls.CodeHelp {
                 builder.append ("::~");
                 builder.append (sym.name ?? sym.parent_symbol.name);
                 builder.append (" ()");
+                return builder.str;
+            } else if (sym is Vala.TypeParameter) {
+                var builder = new StringBuilder ();
+                string parent_symbol_representation = get_symbol_name_representation (sym.parent_symbol, scope);
+                builder.append (sym.name);
+                builder.append (" (type parameter of ");
+                builder.append (parent_symbol_representation);
+                builder.append_c (')');
                 return builder.str;
             }
             warning ("symbol %s unmatched", sym.type_name);

--- a/src/codehelp/codehelp.vala
+++ b/src/codehelp/codehelp.vala
@@ -83,6 +83,23 @@ namespace Vls.CodeHelp {
         return null;
     }
 
+    public Vala.Symbol? lookup_symbol_full_name (string full_name, Vala.Scope scope, out Gee.ArrayList<Vala.Symbol> components = null) {
+        string[] symbol_names = full_name.split (".");
+        Vala.Symbol? current_symbol = lookup_in_scope_and_ancestors (scope, symbol_names[0]);
+        components = new Gee.ArrayList<Vala.Symbol> ();
+
+        if (current_symbol != null)
+            components.add (current_symbol);
+
+        for (int i = 1; i < symbol_names.length && current_symbol != null; i++) {
+            current_symbol = current_symbol.scope.lookup (symbol_names[i]);
+            if (current_symbol != null)
+                components.add (current_symbol);
+        }
+
+        return current_symbol;
+    }
+
     /**
      * Displays a symbol in a format that's contextualized in the current scope.
      */

--- a/src/codehelp/codehelp.vala
+++ b/src/codehelp/codehelp.vala
@@ -595,6 +595,9 @@ namespace Vls.CodeHelp {
         if (sym is Vala.Constant)
             return get_constant_representation (data_type, (Vala.Constant)sym, scope);
 
+        if (sym is Vala.ErrorCode)
+            return get_symbol_name_representation (sym, scope);
+
         critical ("uncaught data type with symbol (%s with %s as %s)", data_type.to_string (), sym.name, sym.type_name);
         return null;
     }

--- a/src/codehelp/find_symbol.vala
+++ b/src/codehelp/find_symbol.vala
@@ -92,6 +92,11 @@ class Vls.FindSymbol : Vala.CodeVisitor {
 
     public override void visit_source_file (Vala.SourceFile file) {
         file.accept_children (this);
+        // also try all using directives that are attached to the source file
+        foreach (var ud in file.current_using_directives) {
+            if (this.match (ud))
+                result.add (ud);
+        }
     }
 
     public override void visit_addressof_expression (Vala.AddressofExpression expr) {

--- a/src/codehelp/symbolreferences.vala
+++ b/src/codehelp/symbolreferences.vala
@@ -108,13 +108,16 @@ namespace Vls.SymbolReferences {
      * ``Namespace.TypeName``.
      *
      * @param code_node             A code node in the AST. Its ``source_reference`` must be non-``null``.
-     * @param symbol                The symbol to replace inside the code node.
+     * @param symbol                The symbol to replace inside the code node. ``symbol.name`` must be non-``null``.
      * @return                      The replacement range, or ``null`` if ``symbol.name`` is not inside it
      */
     Range? get_replacement_range (Vala.CodeNode code_node, Vala.Symbol symbol) {
         string representation = CodeHelp.get_expression_representation (code_node);
         int index_of_symbol;
         MatchInfo match_info;
+
+        if (symbol.name == null)
+            return null;
 
         if (/^\s*foreach\s?\(.+\s+(\S+)\s+in\s+.+\)\s*$/m.match (representation, 0, out match_info)) {
             int start, end;
@@ -369,16 +372,24 @@ namespace Vls.SymbolReferences {
             Collection<Pair<Vala.Symbol, Range>>? components = null;
 
             if (node == symbol || CodeHelp.namespaces_equal (node, symbol)) {
-                references[(!) get_replacement_range (node, (Vala.Symbol)node)] = node;
+                var rrange = get_replacement_range (node, (Vala.Symbol)node);
+                if (rrange != null)
+                    references[rrange] = node;
             } else if (node is Vala.Expression && ((Vala.Expression)node).symbol_reference == symbol) {
                 if (node is Vala.MemberAccess)
                     components = get_visible_components_of_code_node (node);
             } else if (node is Vala.UsingDirective && ((Vala.UsingDirective)node).namespace_symbol == symbol) {
-                references[(!) get_replacement_range (node, symbol)] = node;
+                var rrange = get_replacement_range (node, symbol);
+                if (rrange != null)
+                    references[rrange] = node;
             } else if (node is Vala.CreationMethod && ((Vala.CreationMethod)node).parent_symbol == symbol) {
-                references[(!) get_replacement_range (node, symbol)] = node;
+                var rrange = get_replacement_range (node, symbol);
+                if (rrange != null)
+                    references[rrange] = node;
             } else if (node is Vala.Destructor && ((Vala.Destructor)node).parent_symbol == symbol) {
-                references[(!) get_replacement_range (node, symbol)] = node;
+                var rrange = get_replacement_range (node, symbol);
+                if (rrange != null)
+                    references[rrange] = node;
             } else {
                 if (node is Vala.Namespace || node is Vala.TypeSymbol)
                     components = get_visible_components_of_code_node (node);

--- a/src/codehelp/symbolreferences.vala
+++ b/src/codehelp/symbolreferences.vala
@@ -113,26 +113,30 @@ namespace Vls.SymbolReferences {
      */
     Range? get_replacement_range (Vala.CodeNode code_node, Vala.Symbol symbol) {
         string representation = CodeHelp.get_expression_representation (code_node);
-        int last_index_of_symbol;
+        int index_of_symbol;
         MatchInfo match_info;
 
         if (/^\s*foreach\s?\(.+\s+(\S+)\s+in\s+.+\)\s*$/m.match (representation, 0, out match_info)) {
             int start, end;
             if (match_info.fetch_pos (1, out start, out end) && match_info.fetch (1) == symbol.name)
-                last_index_of_symbol = start;
+                index_of_symbol = start;
             else
-                last_index_of_symbol = -1;
-        } else
-            last_index_of_symbol = representation.last_index_of (symbol.name);
+                index_of_symbol = -1;
+        } else {
+            if (code_node is Vala.Symbol)
+                index_of_symbol = representation.index_of (symbol.name);
+            else // for more complex expressions
+                index_of_symbol = representation.last_index_of (symbol.name);
+        }
 
-        if (last_index_of_symbol == -1)
+        if (index_of_symbol == -1)
             return null;
         
         return get_narrowed_source_reference (
             code_node.source_reference,
             representation,
-            last_index_of_symbol,
-            last_index_of_symbol + symbol.name.length);
+            index_of_symbol,
+            index_of_symbol + symbol.name.length);
     }
 
     /**

--- a/src/codehelp/symbolreferences.vala
+++ b/src/codehelp/symbolreferences.vala
@@ -90,7 +90,17 @@ namespace Vls.SymbolReferences {
         var range = new Range.from_sourceref (code_node.source_reference);
 
         string representation = CodeHelp.get_expression_representation (code_node);
-        int last_index_of_symbol = representation.last_index_of (symbol.name);
+        int last_index_of_symbol;
+        MatchInfo match_info;
+
+        if (/^\s*foreach\s?\(.+\s+(\S+)\s+in\s+.+\)\s*$/m.match (representation, 0, out match_info)) {
+            int start, end;
+            if (match_info.fetch_pos (1, out start, out end) && match_info.fetch (1) == symbol.name)
+                last_index_of_symbol = start;
+            else
+                last_index_of_symbol = -1;
+        } else
+            last_index_of_symbol = representation.last_index_of (symbol.name);
 
         if (last_index_of_symbol == -1)
             return null;

--- a/src/codehelp/symbolreferences.vala
+++ b/src/codehelp/symbolreferences.vala
@@ -1,0 +1,336 @@
+using LanguageServer;
+using Gee;
+
+/** 
+ * Contains routines for analyzing references to symbols across the project.
+ * Used by `textDocument/definition`, `textDocument/rename`, `textDocument/prepareRename`,
+ * `textDocument/references`, and `textDocument/documentHighlight`.
+ */
+namespace Vls.SymbolReferences {
+    /**
+     * Find a symbol in ``context`` matching ``symbol`` or ``null``.
+     *
+     * @param context       the {@link Vala.CodeContext} to search for a matching symbol in
+     * @param symbol        the symbol to match, which comes from a different {@link Vala.CodeContext}
+     * @return              the matching symbol in ``context``, or ``null`` if one could not be found
+     */
+    public Vala.Symbol? find_matching_symbol (Vala.CodeContext context, Vala.Symbol symbol) {
+        var symbols = new GLib.Queue<Vala.Symbol> ();
+        Vala.Symbol? matching_sym = null;
+
+        // walk up the symbol hierarchy to the root
+        for (Vala.Symbol? current_sym = symbol;
+             current_sym != null && current_sym.name != null && current_sym.to_string () != "(root namespace)";
+             current_sym = current_sym.parent_symbol) {
+            symbols.push_head (current_sym);
+        }
+
+        matching_sym = context.root.scope.lookup (symbols.pop_head ().name);
+        while (!symbols.is_empty () && matching_sym != null) {
+            var parent_sym = matching_sym;
+            var symtab = parent_sym.scope.get_symbol_table ();
+            if (symtab != null) {
+                var current_sym = symbols.pop_head ();
+                matching_sym = symtab[current_sym.name];
+                string? gir_name = null;
+                // look for the GIR version of current_sym instead
+                if (matching_sym == null && (gir_name = current_sym.get_attribute_string ("GIR", "name")) != null) {
+                    matching_sym = symtab[gir_name];
+                    if (matching_sym != null && matching_sym.source_reference.file.file_type != Vala.SourceFileType.PACKAGE)
+                        matching_sym = null;
+                }
+            } else {
+                // workaround: "GLib" namespace may be empty when dealing with GLib-2.0.gir (instead, "G" namespace will be populated)
+                if (matching_sym.name == "GLib") {
+                    matching_sym = context.root.scope.lookup ("G");
+                } else 
+                    matching_sym = null;
+            }
+        }
+
+        if (!symbols.is_empty ())
+            return null;
+
+        return matching_sym;
+    }
+
+    /**
+     * Gets the symbol you really want, not something from a generated file.
+     *
+     * If `symbol` comes from a generated file (eg. a VAPI), then
+     * it would be more useful to show the file specific to the compilation
+     * that generated the file.
+     */
+    Vala.Symbol find_real_symbol (Project project, Vala.Symbol symbol) {
+        if (symbol.source_reference == null || symbol.source_reference.file == null)
+            return symbol;
+
+        Compilation alter_comp;
+        if (project.lookup_compilation_for_output_file (symbol.source_reference.file.filename, out alter_comp)) {
+            Vala.Symbol? matching_sym;
+            if ((matching_sym = SymbolReferences.find_matching_symbol (alter_comp.code_context, symbol)) != null)
+                return matching_sym;
+        }
+        return symbol;
+    }
+
+    /**
+     * Gets the range of a symbol name in a code node. For example, 
+     * if we are replacing a method symbol, for each method call where that symbol
+     * appears, we only want to replace the portion of the text that contains the 
+     * symbol. This means we have to narrow the {@link Vala.SourceReference} of
+     * the expression. This same problem exists for data types, where we may wish
+     * to replace ``TypeName`` in every instance of ``Namespace.TypeName``.
+     *
+     * @param code_node             A code node in the AST. Its ``source_reference`` must be non-``null``.
+     * @param symbol                The symbol to replace inside the code node.
+     * @return                      The replacement range, or ``null`` if ``symbol.name`` is not inside it
+     */
+    Range? get_replacement_range (Vala.CodeNode code_node, Vala.Symbol symbol) {
+        var range = new Range.from_sourceref (code_node.source_reference);
+
+        string representation = CodeHelp.get_expression_representation (code_node);
+        int last_index_of_symbol = representation.last_index_of (symbol.name);
+
+        if (last_index_of_symbol == -1)
+            return null;
+        
+        // move the start of the range up [last_index_of_symbol] characters
+        string prefix = representation[0:last_index_of_symbol];
+        int last_index_of_newline_in_prefix = prefix.last_index_of_char ('\n');
+
+        if (last_index_of_newline_in_prefix == -1) {
+            range.start = range.start.translate (0, last_index_of_symbol);
+        } else {
+            int newline_count = 0;
+
+            foreach (uint character in prefix.data)
+                if ((char)character == '\n')
+                    newline_count++;
+
+            range.start = range.start.translate (newline_count, last_index_of_symbol - last_index_of_newline_in_prefix);
+        }
+
+        // move the end of the range back [length(symbol_name)] characters
+        string suffix = representation[(last_index_of_symbol+symbol.name.length):representation.length];
+        int last_index_of_newline_in_suffix = suffix.last_index_of_char ('\n');
+
+        if (last_index_of_newline_in_suffix == -1) {
+            range.end = range.end.translate (0, -(representation.length - (last_index_of_symbol + symbol.name.length)));
+        } else {
+            int newline_count = 0;
+
+            foreach (uint character in suffix.data)
+                if ((char)character == '\n')
+                    newline_count++;
+            
+            range.end = range.end.translate (-newline_count, -(last_index_of_newline_in_suffix - (last_index_of_symbol + symbol.name.length)));
+        }
+
+        return range;
+    }
+
+    /** 
+     * Because a {@link Vala.DataType} or {@link Vala.Symbol} code node 
+     * does not have precise source reference information for each component
+     * that the parser found before this data type/symbol was constructed by the
+     * semantic analyzer, we use this to get all of the visible components
+     * (that is, part of the original source
+     * code spanning the {@link Vala.SourceReference}) of the ``code_node``.
+     * If ``code_node.source_reference`` is ``null``, then this function returns
+     * an empty list.
+     *
+     * @param code_node         The code node. Should be either a 
+     *                          {@link Vala.DataType}, a {@link Vala.MemberAccess},
+     *                          or a {@link Vala.Namespace}.
+     * @return                  A collection of components found at the source code 
+     *                          spanned by the data type code node. For example, if
+     *                          the data type is {@link GLib.File}, then perhaps the
+     *                          source code was ``File`` (if ``GLib`` is imported
+     *                          elsewhere), or perhaps it was ``GLib.File``. If the
+     *                          former, then the returned collection contains just
+     *                          ``File``. If the latter, then the returned collection
+     *                          contains both ``GLib`` and ``File``.
+     */
+    Collection<Pair<Vala.Symbol, Range>> get_visible_components_of_code_node (Vala.CodeNode code_node) {
+        var components = new ArrayQueue<Pair<Vala.Symbol, Range>> ();
+        Vala.Symbol? symbol = null;
+
+        if (code_node is Vala.DataType)
+            symbol = ((Vala.DataType)code_node).symbol;
+        else if (code_node is Vala.Symbol)
+            symbol = (Vala.Symbol) code_node;
+        else if (code_node is Vala.MemberAccess)
+            symbol = ((Vala.MemberAccess)code_node).symbol_reference;
+
+        if (code_node.source_reference != null && symbol != null) {
+            string representation = CodeHelp.get_expression_representation (code_node);
+            int end = representation.length;
+
+            // debug ("got representation for (%s) %s @ %s => %s", code_node.type_name, code_node.to_string (), code_node.source_reference.to_string (), representation);
+            if (code_node is Vala.TypeSymbol || code_node is Vala.Namespace) {
+                MatchInfo match_info;
+                if (/((public|private|protected|internal)?\s*?(abstract)?\s*?(class|interface|errordomain|struct|enum|namespace)\s+)?(\w+(\.\w+)*)/m
+                    .match (representation, 0, out match_info)) {
+                    representation = (!) match_info.fetch (0);
+                    end = representation.length;
+                    // debug ("refined %s representation => %s", code_node.type_name, representation);
+                }
+            }
+
+            // skip '?'
+            if (end > 0 && representation[end - 1] == '?')
+                end--;
+
+            // skip any type parameters
+            if (end > 0 && representation[end - 1] == '>') {
+                end--;
+
+                int unbalanced_rangles = 1;
+                while (unbalanced_rangles > 0 && end > 0) {
+                    if (representation[end - 1] == '<')
+                        unbalanced_rangles--;
+                    else if (representation[end - 1] == '>')
+                        unbalanced_rangles++;
+                    end--;
+                }
+
+                if (unbalanced_rangles != 0)
+                    warning ("unbalanced right angles in representation of code node %s: %s", code_node.type_name, representation);
+            }
+
+            for (var current_sym = symbol; 
+                current_sym != null && current_sym.name != null && end >= current_sym.name.length;
+                current_sym = current_sym.parent_symbol) {
+                int last_dot_char = -1;
+                for (int i = 0; i < end; i++)
+                    if (representation[i] == '.')
+                        last_dot_char = i;
+                if (representation.substring (last_dot_char + 1, end - (last_dot_char + 1)) == current_sym.name) {
+                    int start = end - current_sym.name.length;
+
+                    string prefix = representation[0:start+1];
+                    int last_nl_pos;
+                    int nl_count = (int) Util.count_chars_in_string (prefix, '\n', out last_nl_pos);
+                    int begin_line = code_node.source_reference.begin.line + nl_count;
+                    int begin_column = last_nl_pos == -1 ? code_node.source_reference.begin.column + start : start - last_nl_pos;
+                    int end_line = begin_line;
+                    int end_column = begin_column + current_sym.name.length - 1;
+                    var sr = new Vala.SourceReference (code_node.source_reference.file,
+                        Vala.SourceLocation (null, begin_line, begin_column),
+                        Vala.SourceLocation (null, end_line, end_column));
+
+                    components.offer_head (new Pair<Vala.Symbol, Range> (current_sym, new Range.from_sourceref (sr)));
+
+                    end -= current_sym.name.length;
+                    // skip spaces, then '.', then spaces
+                    while (end > 0 && representation[end - 1].isspace ())
+                        end--;
+                    if (end > 0 && representation[end - 1] == '.') {
+                        end--;
+                    } else if (end > 0) {
+                        string substring = representation.substring (0, end);
+                        // get last word
+                        int last_space_pos = substring.last_index_of_char (' ');
+                        if (last_space_pos != -1)
+                            substring = substring.substring (last_space_pos + 1);
+                        if (substring != "unowned" && substring != "owned" && substring != "weak" && substring != "namespace" &&
+                            substring != "class" && substring != "interface" && substring != "struct" &&
+                            substring != "errordomain" && substring != "enum")
+                            warning ("expected `.', got `%s' in symbol %s for %s (%s)", substring, symbol.get_full_name (), symbol.type_name, representation);
+                        else
+                            end = 0;
+                        break;
+                    }
+                    while (end > 0 && representation[end - 1].isspace ())
+                        end--;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        return components;
+    }
+
+    /**
+     * List all references to @sym in @file
+     *
+     * @param file                  the file to search for references in
+     * @param symbol                the symbol to search for references to
+     * @param include_declaration   whether to include declarations in references
+     * @param references            the collection to fill with references
+     */
+    void list_in_file (Vala.SourceFile file, Vala.Symbol symbol, bool include_declaration, HashMap<Range, Vala.CodeNode> references) {
+        new SymbolVisitor<HashMap<Range, Vala.CodeNode>> (file, symbol, references, include_declaration,
+        (node, symbol, references) => {
+            Collection<Pair<Vala.Symbol, Range>>? components = null;
+
+            if (node == symbol || CodeHelp.namespaces_equal (node, symbol)) {
+                references[(!) get_replacement_range (node, (Vala.Symbol)node)] = node;
+            } else if (node is Vala.Expression && ((Vala.Expression)node).symbol_reference == symbol) {
+                if (node is Vala.MemberAccess)
+                    components = get_visible_components_of_code_node (node);
+            } else if (node is Vala.UsingDirective && ((Vala.UsingDirective)node).namespace_symbol == symbol) {
+                references[(!) get_replacement_range (node, symbol)] = node;
+            } else if (node is Vala.CreationMethod && ((Vala.CreationMethod)node).parent_symbol == symbol) {
+                references[(!) get_replacement_range (node, symbol)] = node;
+            } else if (node is Vala.Destructor && ((Vala.Destructor)node).parent_symbol == symbol) {
+                references[(!) get_replacement_range (node, symbol)] = node;
+            } else {
+                if (node is Vala.Namespace || node is Vala.TypeSymbol)
+                    components = get_visible_components_of_code_node (node);
+                else if (node is Vala.DataType) {
+                    // it's expensive to run get_visible_components_of_code_node() every time we
+                    // see a ValaDataType, so only run it if the source reference for the ValaDataType
+                    // could potentially match @symbol_to_find
+                    for (var current_sym = ((Vala.DataType)node).symbol; current_sym != null; 
+                        current_sym = current_sym.parent_symbol) {
+                        if (symbol == current_sym) {
+                            components = get_visible_components_of_code_node (node);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (components != null) {
+                var result = components.first_match (pair => pair.first == symbol || CodeHelp.namespaces_equal (pair.first, symbol));
+                if (result != null)
+                    references[result.second] = node;
+            }
+        });
+    }
+
+    /** 
+     * It's possible that a symbol can be used across build targets within a
+     * project. This returns a list of all pairs of ``(compilation, symbol)``
+     * matching @sym where ``symbol`` is defined within ``compilation``.
+     *
+     * @param project       the project to search for a symbol in
+     * @param symbol        the symbol to search for
+     * @return              a list of pairs of ``(compilation, symbol)``
+     */
+    Collection<Pair<Compilation, Vala.Symbol>> get_compilations_using_symbol (Project project, Vala.Symbol symbol) {
+        var compilations = new ArrayList<Pair<Compilation, Vala.Symbol>> ();
+
+        foreach (var compilation in project.get_compilations ()) {
+            Vala.Symbol? matching_sym = find_matching_symbol (compilation.code_context, symbol);
+            if (matching_sym != null)
+                compilations.add (new Pair<Compilation, Vala.Symbol> (compilation, matching_sym));
+        }
+
+        // find_matching_symbol() isn't reliable with local variables, especially those declared
+        // in lambdas, which can change names after recompilation.
+        if (symbol is Vala.LocalVariable) {
+            project.get_compilations ()
+                .filter (c => symbol.source_reference.file in c.code_context.get_source_files ())
+                .foreach (compilation => {
+                    compilations.add (new Pair<Compilation, Vala.Symbol> (compilation, symbol));
+                    return false;
+                });
+        }
+
+        return compilations;
+    }
+}

--- a/src/codehelp/symbolvisitor.vala
+++ b/src/codehelp/symbolvisitor.vala
@@ -26,6 +26,11 @@ class Vls.SymbolVisitor<G> : CodeVisitor {
         this.include_declaration = include_declaration;
         this.func = func;
         visit_source_file (file);
+
+        // XXX: sometimes the CodeVisitor does not see a local variable,
+        // especially if it is declared as part of a foreach statement
+        if (symbol is LocalVariable && filter (symbol))
+            func (symbol, symbol, data);
     }
 
     private bool filter (CodeNode node) {

--- a/src/codehelp/symbolvisitor.vala
+++ b/src/codehelp/symbolvisitor.vala
@@ -1,0 +1,727 @@
+using Vala;
+
+/**
+ * Useful for when we need to iterate over the nodes in a document
+ * in a generic fashion, in search of a code node that matches a given
+ * symbol in some way, or that we can perform an operation on, given
+ * knowledge of a symbol to compare, custom user data, and the code
+ * node we are presently exploring.
+ */
+class Vls.SymbolVisitor<G> : CodeVisitor {
+    [CCode (has_target = false)]
+    public delegate void Func<G> (CodeNode code_node, Symbol symbol, G user_data);
+
+    private SourceFile file;
+    private Symbol symbol;
+    private G data;
+    private Gee.HashSet<CodeNode> seen;
+    private bool include_declaration;
+    private Func<G> func;
+
+    public SymbolVisitor (SourceFile file, Symbol symbol, G data, bool include_declaration, Func<G> func) {
+        this.file = file;
+        this.symbol = symbol;
+        this.data = data;
+        this.seen = new Gee.HashSet<CodeNode> ();
+        this.include_declaration = include_declaration;
+        this.func = func;
+        visit_source_file (file);
+    }
+
+    private bool filter (CodeNode node) {
+        var sr = node.source_reference;
+        if (sr == null)
+            return false;
+        if (sr.file != file)
+            return false;
+        if (sr.begin.line > sr.end.line) {
+            warning ("wtf Vala: %s @ %s", node.type_name, sr.to_string ());
+            return false;
+        }
+        return true;
+    }
+
+    public override void visit_source_file (SourceFile source_file) {
+        source_file.accept_children (this);
+        foreach (var using_directive in source_file.current_using_directives)
+            visit_using_directive (using_directive);
+    }
+
+    public override void visit_addressof_expression (AddressofExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_array_creation_expression (ArrayCreationExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_assignment (Assignment a) {
+        if (seen.contains (a))
+            return;
+        seen.add (a);
+        if (filter (a))
+            func (a, symbol, data);
+        a.accept_children (this);
+    }
+
+    public override void visit_base_access (BaseAccess expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_binary_expression (BinaryExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_block (Block b) {
+        if (seen.contains (b))
+            return;
+        seen.add (b);
+        if (filter (b))
+            func (b, symbol, data);
+        b.accept_children (this);
+    }
+
+    public override void visit_boolean_literal (BooleanLiteral lit) {
+        if (seen.contains (lit))
+            return;
+        seen.add (lit);
+        if (filter (lit))
+            func (lit, symbol, data);
+        lit.accept_children (this);
+    }
+
+    public override void visit_break_statement (BreakStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_cast_expression (CastExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_catch_clause (CatchClause clause) {
+        if (seen.contains (clause))
+            return;
+        seen.add (clause);
+        if (filter (clause))
+            func (clause, symbol, data);
+        clause.accept_children (this);
+    }
+
+    public override void visit_character_literal (CharacterLiteral lit) {
+        if (seen.contains (lit))
+            return;
+        seen.add (lit);
+        if (filter (lit))
+            func (lit, symbol, data);
+        lit.accept_children (this);
+    }
+
+    public override void visit_class (Class cl) {
+        if (seen.contains (cl))
+            return;
+        seen.add (cl);
+        if (filter (cl) && include_declaration)
+            func (cl, symbol, data);
+        cl.accept_children (this);
+    }
+
+    public override void visit_conditional_expression (ConditionalExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_constant (Constant c) {
+        if (seen.contains (c))
+            return;
+        seen.add (c);
+        if (filter (c) && include_declaration)
+            func (c, symbol, data);
+        c.accept_children (this);
+    }
+
+    public override void visit_constructor (Constructor c) {
+        if (seen.contains (c))
+            return;
+        seen.add (c);
+        if (filter (c) && include_declaration)
+            func (c, symbol, data);
+        c.accept_children (this);
+    }
+
+    public override void visit_continue_statement (ContinueStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_creation_method (CreationMethod m) {
+        if (seen.contains (m))
+            return;
+        seen.add (m);
+        if (filter (m) && include_declaration)
+            func (m, symbol, data);
+        m.accept_children (this);
+    }
+
+    public override void visit_data_type (DataType type) {
+        if (seen.contains (type))
+            return;
+        seen.add (type);
+        if (filter (type))
+            func (type, symbol, data);
+        type.accept_children (this);
+    }
+
+    public override void visit_declaration_statement (DeclarationStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_delegate (Delegate cb) {
+        if (seen.contains (cb))
+            return;
+        seen.add (cb);
+        if (filter (cb) && include_declaration)
+            func (cb, symbol, data);
+        cb.accept_children (this);
+    }
+
+    public override void visit_delete_statement (DeleteStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+    
+    public override void visit_destructor (Destructor dtor) {
+        if (seen.contains (dtor))
+            return;
+        seen.add (dtor);
+        if (filter (dtor) && include_declaration)
+            func (dtor, symbol, data);
+        dtor.accept_children (this);
+    }
+
+    public override void visit_do_statement (DoStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_element_access (ElementAccess expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_empty_statement (EmptyStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_enum (Enum en) {
+        if (seen.contains (en))
+            return;
+        seen.add (en);
+        if (filter (en) && include_declaration)
+            func (en, symbol, data);
+        en.accept_children (this);
+    }
+
+    public override void visit_enum_value (Vala.EnumValue ev) {
+        if (seen.contains (ev))
+            return;
+        seen.add (ev);
+        if (filter (ev) && include_declaration)
+            func (ev, symbol, data);
+        ev.accept_children (this);
+    }
+
+    public override void visit_error_code (ErrorCode ecode) {
+        if (seen.contains (ecode))
+            return;
+        seen.add (ecode);
+        if (filter (ecode) && include_declaration)
+            func (ecode, symbol, data);
+        ecode.accept_children (this);
+    }
+
+    public override void visit_error_domain (ErrorDomain edomain) {
+        if (seen.contains (edomain))
+            return;
+        seen.add (edomain);
+        if (filter (edomain) && include_declaration)
+            func (edomain, symbol, data);
+        edomain.accept_children (this);
+    }
+
+    /* note: do NOT implement visit_expression () without seen, since
+     * this will, in most cases, be redundant and dramatically
+     * slow down FindSymbol */
+    public override void visit_expression (Expression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_expression_statement (ExpressionStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_field (Field f) {
+        if (seen.contains (f))
+            return;
+        seen.add (f);
+        if (filter (f) && include_declaration)
+            func (f, symbol, data);
+        f.accept_children (this);
+    }
+
+    public override void visit_for_statement (ForStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_foreach_statement (ForeachStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_formal_parameter (Vala.Parameter p) {
+        if (seen.contains (p))
+            return;
+        seen.add (p);
+        if (filter (p) && include_declaration)
+            func (p, symbol, data);
+        p.accept_children (this);
+    }
+
+    public override void visit_if_statement (IfStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_initializer_list (InitializerList list) {
+        if (seen.contains (list))
+            return;
+        seen.add (list);
+        if (filter (list))
+            func (list, symbol, data);
+        list.accept_children (this);
+    }
+
+    public override void visit_integer_literal (IntegerLiteral lit) {
+        if (seen.contains (lit))
+            return;
+        seen.add (lit);
+        if (filter (lit))
+            func (lit, symbol, data);
+        lit.accept_children (this);
+    }
+
+    public override void visit_interface (Interface iface) {
+        if (seen.contains (iface))
+            return;
+        seen.add (iface);
+        if (filter (iface) && include_declaration)
+            func (iface, symbol, data);
+        iface.accept_children (this);
+    }
+
+    public override void visit_lambda_expression (LambdaExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_local_variable (LocalVariable local) {
+        if (seen.contains (local))
+            return;
+        seen.add (local);
+        if (filter (local) && (include_declaration || !(local.parent_node is DeclarationStatement)))
+            func (local, symbol, data);
+        local.accept_children (this);
+    }
+
+    public override void visit_lock_statement (LockStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_loop (Loop stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_member_access (MemberAccess expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_method (Method m) {
+        if (seen.contains (m))
+            return;
+        seen.add (m);
+        if (filter (m) && include_declaration)
+            func (m, symbol, data);
+        m.accept_children (this);
+    }
+
+    public override void visit_method_call (MethodCall expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_namespace (Namespace ns) {
+        if (seen.contains (ns))
+            return;
+        seen.add (ns);
+        if (filter (ns))
+            func (ns, symbol, data);
+        ns.accept_children (this);
+    }
+
+    public override void visit_null_literal (NullLiteral lit) {
+        if (seen.contains (lit))
+            return;
+        seen.add (lit);
+        if (filter (lit))
+            func (lit, symbol, data);
+        lit.accept_children (this);
+    }
+
+    public override void visit_object_creation_expression (ObjectCreationExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_pointer_indirection (PointerIndirection expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_postfix_expression (PostfixExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_property (Property prop) {
+        if (seen.contains (prop))
+            return;
+        seen.add (prop);
+        if (filter (prop) && include_declaration)
+            func (prop, symbol, data);
+        prop.accept_children (this);
+    }
+
+    public override void visit_property_accessor (PropertyAccessor acc) {
+        if (seen.contains (acc))
+            return;
+        seen.add (acc);
+        if (filter (acc) && include_declaration)
+            func (acc, symbol, data);
+        acc.accept_children (this);
+    }
+
+    public override void visit_real_literal (RealLiteral lit) {
+        if (seen.contains (lit))
+            return;
+        seen.add (lit);
+        if (filter (lit))
+            func (lit, symbol, data);
+        lit.accept_children (this);
+    }
+
+    public override void visit_reference_transfer_expression (ReferenceTransferExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_regex_literal (RegexLiteral lit) {
+        if (seen.contains (lit))
+            return;
+        seen.add (lit);
+        if (filter (lit))
+            func (lit, symbol, data);
+        lit.accept_children (this);
+    }
+
+    public override void visit_return_statement (ReturnStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_signal (Vala.Signal sig) {
+        if (seen.contains (sig))
+            return;
+        seen.add (sig);
+        if (filter (sig) && include_declaration)
+            func (sig, symbol, data);
+        sig.accept_children (this);
+    }
+
+    public override void visit_sizeof_expression (SizeofExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_slice_expression (SliceExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_string_literal (StringLiteral lit) {
+        if (seen.contains (lit))
+            return;
+        seen.add (lit);
+        if (filter (lit))
+            func (lit, symbol, data);
+        lit.accept_children (this);
+    }
+
+    public override void visit_struct (Struct st) {
+        if (seen.contains (st))
+            return;
+        seen.add (st);
+        if (filter (st) && include_declaration)
+            func (st, symbol, data);
+        st.accept_children (this);
+    }
+
+    public override void visit_switch_label (SwitchLabel label) {
+        if (seen.contains (label))
+            return;
+        seen.add (label);
+        if (filter (label))
+            func (label, symbol, data);
+        label.accept_children (this);
+    }
+
+    public override void visit_switch_section (SwitchSection section) {
+        if (seen.contains (section))
+            return;
+        seen.add (section);
+        if (filter (section))
+            func (section, symbol, data);
+        section.accept_children (this);
+    }
+
+    public override void visit_switch_statement (SwitchStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_template (Template tmpl) {
+        if (seen.contains (tmpl))
+            return;
+        seen.add (tmpl);
+        if (filter (tmpl))
+            func (tmpl, symbol, data);
+        tmpl.accept_children (this);
+    }
+
+    public override void visit_throw_statement (ThrowStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_try_statement (TryStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_type_check (TypeCheck expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_type_parameter (TypeParameter p) {
+        if (seen.contains (p))
+            return;
+        seen.add (p);
+        if (filter (p))
+            func (p, symbol, data);
+        p.accept_children (this);
+    }
+
+    public override void visit_typeof_expression (TypeofExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_unary_expression (UnaryExpression expr) {
+        if (seen.contains (expr))
+            return;
+        seen.add (expr);
+        if (filter (expr))
+            func (expr, symbol, data);
+        expr.accept_children (this);
+    }
+
+    public override void visit_unlock_statement (UnlockStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+
+    public override void visit_using_directive (UsingDirective ud) {
+        if (seen.contains (ud))
+            return;
+        seen.add (ud);
+        if (filter (ud))
+            func (ud, symbol, data);
+        ud.accept_children (this);
+    }
+
+    public override void visit_yield_statement (YieldStatement stmt) {
+        if (seen.contains (stmt))
+            return;
+        seen.add (stmt);
+        if (filter (stmt))
+            func (stmt, symbol, data);
+        stmt.accept_children (this);
+    }
+}

--- a/src/documentation/girdocumentation.vala
+++ b/src/documentation/girdocumentation.vala
@@ -345,7 +345,7 @@ class Vls.GirDocumentation {
      * Find the GIR symbol related to @sym
      */
     public Vala.Symbol? find_gir_symbol (Vala.Symbol sym) {
-        var found_sym = Util.find_matching_symbol (context, sym);
+        var found_sym = SymbolReferences.find_matching_symbol (context, sym);
 
         // fallback to C name
         if (found_sym == null) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,6 +6,8 @@ vls_src = files([
   'codehelp/find_symbol.vala',
   'codehelp/signaturehelpengine.vala',
   'codehelp/symbolextractor.vala',
+  'codehelp/symbolreferences.vala',
+  'codehelp/symbolvisitor.vala',
   'documentation/cnamemapper.vala',
   'documentation/doccomment.vala',
   'projects/buildtarget.vala',

--- a/src/projects/textdocument.vala
+++ b/src/projects/textdocument.vala
@@ -8,6 +8,20 @@ class Vls.TextDocument : SourceFile {
     public DateTime last_updated { get; set; default = new DateTime.now (); }
     public int version { get; set; }
 
+    public int last_saved_version { get; private set; }
+    private string? _last_saved_content = null;
+    public string last_saved_content {
+        get {
+            if (_last_saved_content == null)
+                return this.content;
+            return _last_saved_content;
+        }
+        set {
+            _last_saved_content = value;
+            last_saved_version = version;
+        }
+    }
+
     public TextDocument (CodeContext context, File file, string? content = null, bool cmdline = false) throws FileError {
         string? cont = content;
         string uri = file.get_uri ();

--- a/src/protocol.vala
+++ b/src/protocol.vala
@@ -95,12 +95,15 @@ namespace LanguageServer {
          */
         public Position end { get; set; }
 
-        public string to_string () { return @"$start -> $end"; }
+        private string filename;
+
+        public string to_string () { return @"$filename: $start -> $end"; }
 
         public Range.from_sourceref (Vala.SourceReference sref) {
             this.start = new Position.from_libvala (sref.begin);
             this.end = new Position.from_libvala (sref.end);
             this.start.character -= 1;
+            this.filename = sref.file.filename;
         }
 
         public uint hash () {
@@ -190,6 +193,20 @@ namespace LanguageServer {
         public string uri { get; set; }
     }
 
+    class VersionedTextDocumentIdentifier : TextDocumentIdentifier {
+        /**
+         * The version number of this document. If a versioned text document identifier
+         * is sent from the server to the client and the file is not open in the editor
+         * (the server has not received an open notification before) the server can send
+         * `null` to indicate that the version is known and the content on disk is the
+         * master (as speced with document content ownership).
+         *
+         * The version number of a document will increase after each change, including
+         * undo/redo. The number doesn't need to be consecutive.
+         */
+        public int version { get; set; default = -1; }
+    }
+
     class TextDocumentPositionParams : Object {
         public TextDocumentIdentifier textDocument { get; set; }
         public Position position { get; set; }
@@ -206,10 +223,13 @@ namespace LanguageServer {
         public string uri { get; set; }
         public Range range { get; set; }
 
-        internal Location () {}
         public Location.from_sourceref (Vala.SourceReference sref) {
-            this.uri = File.new_for_commandline_arg (sref.file.filename).get_uri ();
-            this.range = new Range.from_sourceref (sref);
+            this (sref.file.filename, new Range.from_sourceref (sref));
+        }
+
+        public Location (string filename, Range range) {
+            this.uri = File.new_for_commandline_arg (filename).get_uri ();
+            this.range = range;
         }
     }
 
@@ -309,10 +329,7 @@ namespace LanguageServer {
         public SymbolInformation.from_document_symbol (DocumentSymbol dsym, string uri) {
             this.name = dsym.name;
             this.kind = dsym.kind;
-            this.location = new Location () {
-                uri = uri,
-                range = dsym.range
-            };
+            this.location = new Location (uri, dsym.range);
         }
     }
 
@@ -615,14 +632,32 @@ namespace LanguageServer {
         Operator = 24,
         TypeParameter = 25
     }
-
-    class TextDocumentClientCapabilities : Object {
-        public class DocumentSymbolCapabilities : Object {
-            public bool hierarchicalDocumentSymbolSupport { get; set; }
-        }
-        public DocumentSymbolCapabilities documentSymbol { get; set; default = new DocumentSymbolCapabilities ();}
+    
+    /**
+     * Capabilities of the client/editor for `textDocument/documentSymbol`
+     */
+    class DocumentSymbolCapabilities : Object {
+        public bool hierarchicalDocumentSymbolSupport { get; set; }
     }
 
+    /**
+     * Capabilities of the client/editor for `textDocument/rename`
+     */
+    class RenameClientCapabilities : Object {
+        public bool prepareSupport { get; set; }
+    }
+
+    /**
+     * Capabilities of the client/editor pertaining to language features.
+     */
+    class TextDocumentClientCapabilities : Object {
+        public DocumentSymbolCapabilities documentSymbol { get; set; default = new DocumentSymbolCapabilities ();}
+        public RenameClientCapabilities rename { get; set; default = new RenameClientCapabilities (); }
+    }
+
+    /**
+     * Capabilities of the client/editor.
+     */
     class ClientCapabilities : Object {
         public TextDocumentClientCapabilities textDocument { get; set; default = new TextDocumentClientCapabilities (); }
     }
@@ -736,6 +771,61 @@ namespace LanguageServer {
         }
 
         public bool deserialize_property (string property_name, out Value value, ParamSpec pspec, Json.Node property_node) {
+            error ("deserialization not supported");
+        }
+    }
+
+    /**
+     * A textual edit applicable to a text document.
+     */
+    class TextEdit : Object {
+        /**
+         * The range of the text document to be manipulated. To insert
+         * text into a document create a range where ``start === end``.
+         */
+        public Range range { get; set; }
+
+        /**
+         * The string to be inserted. For delete operations use an
+         * empty string.
+         */
+        public string newText { get; set; }
+    }
+
+    /** 
+     * Describes textual changes on a single text document. The text document is
+     * referred to as a {@link VersionedTextDocumentIdentifier} to allow clients to
+     * check the text document version before an edit is applied. A
+     * {@link TextDocumentEdit} describes all changes on a version ``Si`` and after they are
+     * applied move the document to version ``Si+1``. So the creator of a
+     * {@link TextDocumentEdit} doesn’t need to sort the array of edits or do any kind
+     * of ordering. However the edits must be non overlapping.
+     */
+    class TextDocumentEdit : Object, Json.Serializable {
+        /**
+         * The text document to change.
+         */
+        public VersionedTextDocumentIdentifier textDocument { get; set; }
+
+        /**
+         * The edits to be applied.
+         */
+        public Gee.ArrayList<TextEdit> edits { get; set; default = new Gee.ArrayList<TextEdit> (); }
+
+        public Json.Node serialize_property (string property_name, GLib.Value value, GLib.ParamSpec pspec) {
+            if (property_name != "edits")
+                return default_serialize_property (property_name, value, pspec);
+            
+            var node = new Json.Node (Json.NodeType.ARRAY);
+            node.init_array (new Json.Array ());
+            var array = node.get_array ();
+            foreach (var text_edit in edits) {
+                array.add_element (Json.gobject_serialize (text_edit));
+            }
+            return node;
+        }
+
+        public bool deserialize_property (string property_name, out GLib.Value value, GLib.ParamSpec pspec, Json.Node property_node) {
             error ("deserialization not supported");
         }
     }

--- a/src/server.vala
+++ b/src/server.vala
@@ -790,11 +790,9 @@ class Vls.Server : Object {
                     debug ("best is now the symbol_referenece => %p (%s)", best, best.to_string ());
                 }
             } else if (best is Vala.DataType) {
-                var dt = best as Vala.DataType;
-                if (dt.type_symbol != null)
-                    best = dt.type_symbol;
-                else if (dt.symbol != null)
-                    best = dt.symbol;
+                var dt = (Vala.DataType) best;
+                var et = dt as Vala.ErrorType;
+                best = et != null && et.error_code != null ? et.error_code : dt.symbol;
             } else if (best is Vala.UsingDirective) {
                 best = ((Vala.UsingDirective)best).namespace_symbol;
             } else {
@@ -1084,7 +1082,9 @@ class Vls.Server : Object {
                 symbol = (Vala.Symbol) result;
             } else if (result is Vala.DataType) {
                 data_type = (Vala.DataType) result;
-                symbol = ((Vala.DataType)result).symbol;
+                // we need to handle ValaErrorTypes with error codes especially
+                var et = result as Vala.ErrorType;
+                symbol = et != null && et.error_code != null ? et.error_code : data_type.symbol;
             } else if (result is Vala.UsingDirective) {
                 symbol = ((Vala.UsingDirective)result).namespace_symbol;
             } else {
@@ -1224,9 +1224,10 @@ class Vls.Server : Object {
 
             if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
                 result = ((Vala.Expression) result).symbol_reference;
-            else if (result is Vala.DataType && ((Vala.DataType)result).type_symbol != null)
-                result = ((Vala.DataType) result).type_symbol;
-            else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
+            else if (result is Vala.DataType && ((Vala.DataType)result).symbol != null) {
+                var et = result as Vala.ErrorType;
+                result = et != null && et.error_code != null ? et.error_code : ((Vala.DataType) result).type_symbol;
+            } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
                 result = ((Vala.UsingDirective) result).namespace_symbol;
 
             // ignore lambda expressions and non-symbols
@@ -1505,9 +1506,10 @@ class Vls.Server : Object {
 
             if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
                 result = ((Vala.Expression) result).symbol_reference;
-            else if (result is Vala.DataType && ((Vala.DataType)result).type_symbol != null)
-                result = ((Vala.DataType) result).type_symbol;
-            else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
+            else if (result is Vala.DataType && ((Vala.DataType)result).symbol != null) {
+                var et = result as Vala.ErrorType;
+                result = et != null && et.error_code != null ? et.error_code : ((Vala.DataType) result).symbol;
+            } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
                 result = ((Vala.UsingDirective) result).namespace_symbol;
 
             // ignore lambda expressions and non-symbols
@@ -1655,9 +1657,10 @@ class Vls.Server : Object {
 
             if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
                 result = ((Vala.Expression) result).symbol_reference;
-            else if (result is Vala.DataType && ((Vala.DataType)result).type_symbol != null)
-                result = ((Vala.DataType) result).type_symbol;
-            else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
+            else if (result is Vala.DataType && ((Vala.DataType)result).symbol != null) {
+                var et = result as Vala.ErrorType;
+                result = et != null && et.error_code != null ? et.error_code : ((Vala.DataType) result).symbol;
+            } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
                 result = ((Vala.UsingDirective) result).namespace_symbol;
 
             // ignore lambda expressions and non-symbols

--- a/src/server.vala
+++ b/src/server.vala
@@ -790,9 +790,7 @@ class Vls.Server : Object {
                     debug ("best is now the symbol_referenece => %p (%s)", best, best.to_string ());
                 }
             } else if (best is Vala.DataType) {
-                var dt = (Vala.DataType) best;
-                var et = dt as Vala.ErrorType;
-                best = et != null && et.error_code != null ? et.error_code : dt.symbol;
+                best = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) best);
             } else if (best is Vala.UsingDirective) {
                 best = ((Vala.UsingDirective)best).namespace_symbol;
             } else {
@@ -1082,9 +1080,7 @@ class Vls.Server : Object {
                 symbol = (Vala.Symbol) result;
             } else if (result is Vala.DataType) {
                 data_type = (Vala.DataType) result;
-                // we need to handle ValaErrorTypes with error codes especially
-                var et = result as Vala.ErrorType;
-                symbol = et != null && et.error_code != null ? et.error_code : data_type.symbol;
+                symbol = SymbolReferences.get_symbol_data_type_refers_to (data_type);
             } else if (result is Vala.UsingDirective) {
                 symbol = ((Vala.UsingDirective)result).namespace_symbol;
             } else {
@@ -1224,9 +1220,8 @@ class Vls.Server : Object {
 
             if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
                 result = ((Vala.Expression) result).symbol_reference;
-            else if (result is Vala.DataType && ((Vala.DataType)result).symbol != null) {
-                var et = result as Vala.ErrorType;
-                result = et != null && et.error_code != null ? et.error_code : ((Vala.DataType) result).type_symbol;
+            else if (result is Vala.DataType) {
+                result = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) result);
             } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
                 result = ((Vala.UsingDirective) result).namespace_symbol;
 
@@ -1506,9 +1501,8 @@ class Vls.Server : Object {
 
             if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
                 result = ((Vala.Expression) result).symbol_reference;
-            else if (result is Vala.DataType && ((Vala.DataType)result).symbol != null) {
-                var et = result as Vala.ErrorType;
-                result = et != null && et.error_code != null ? et.error_code : ((Vala.DataType) result).symbol;
+            else if (result is Vala.DataType) {
+                result = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) result);
             } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
                 result = ((Vala.UsingDirective) result).namespace_symbol;
 
@@ -1657,9 +1651,8 @@ class Vls.Server : Object {
 
             if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
                 result = ((Vala.Expression) result).symbol_reference;
-            else if (result is Vala.DataType && ((Vala.DataType)result).symbol != null) {
-                var et = result as Vala.ErrorType;
-                result = et != null && et.error_code != null ? et.error_code : ((Vala.DataType) result).symbol;
+            else if (result is Vala.DataType) {
+                result = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) result);
             } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
                 result = ((Vala.UsingDirective) result).namespace_symbol;
 

--- a/src/server.vala
+++ b/src/server.vala
@@ -1555,6 +1555,10 @@ class Vls.Server : Object {
             foreach (var btarget in selected_project.get_compilations ())
                 generated_vapis.add_all (btarget.output);
             var shown_files = new HashSet<File> (Util.file_hash, Util.file_equal);
+            bool is_abstract_or_virtual = 
+                symbol is Vala.Property && (((Vala.Property)symbol).is_virtual || ((Vala.Property)symbol).is_abstract) ||
+                symbol is Vala.Method && (((Vala.Method)symbol).is_virtual || ((Vala.Method)symbol).is_abstract) ||
+                symbol is Vala.Signal && ((Vala.Signal)symbol).is_virtual;
             foreach (var btarget_w_sym in SymbolReferences.get_compilations_using_symbol (selected_project, symbol))
                 foreach (Vala.SourceFile project_file in btarget_w_sym.first.code_context.get_source_files ()) {
                     // don't show symbol from generated VAPI
@@ -1564,6 +1568,10 @@ class Vls.Server : Object {
                     var file_references = new HashMap<Range, Vala.CodeNode> ();
                     debug ("[%s] looking for references in %s ...", method, file.get_uri ());
                     SymbolReferences.list_in_file (project_file, btarget_w_sym.second, true, file_references);
+                    if (is_abstract_or_virtual) {
+                        debug ("[%s] looking for implementations of abstract/virtual symbol in %s ...", method, file.get_uri ());
+                        SymbolReferences.list_implementations_of_virtual_symbol (project_file, btarget_w_sym.second, file_references);
+                    }
                     if (!(project_file is TextDocument) && file_references.size > 0) {
                         // This means we have found references in a file that was added automatically,
                         // which should not be modified.

--- a/src/server.vala
+++ b/src/server.vala
@@ -812,6 +812,8 @@ class Vls.Server : Object {
                     best = dt.type_symbol;
                 else if (dt.symbol != null)
                     best = dt.symbol;
+            } else if (best is Vala.UsingDirective) {
+                best = ((Vala.UsingDirective)best).namespace_symbol;
             } else {
                 debug ("[%s] best is %s, which we can't handle", method, best != null ? best.type_name : null);
                 try {
@@ -1100,6 +1102,8 @@ class Vls.Server : Object {
             } else if (result is Vala.DataType) {
                 data_type = (Vala.DataType) result;
                 symbol = ((Vala.DataType)result).symbol;
+            } else if (result is Vala.UsingDirective) {
+                symbol = ((Vala.UsingDirective)result).namespace_symbol;
             } else {
                 warning ("result as %s not matched", result.type_name);
             }
@@ -1216,7 +1220,8 @@ class Vls.Server : Object {
         }
         var fs2 = new FindSymbol.with_filter (file, sym, 
             (needle, node) => node == needle || 
-                (node is Vala.Expression && ((Vala.Expression)node).symbol_reference == needle), include_declaration);
+                (node is Vala.Expression && ((Vala.Expression)node).symbol_reference == needle ||
+                (node is Vala.UsingDirective) && ((Vala.UsingDirective)node).namespace_symbol == needle), include_declaration);
         foreach (var node in fs2.result)
             if (!(node.source_reference.to_string () in unique_srefs)) {
                 references.add (node);
@@ -1277,6 +1282,8 @@ class Vls.Server : Object {
                 result = ((Vala.Expression) result).symbol_reference;
             else if (result is Vala.DataType && ((Vala.DataType)result).type_symbol != null)
                 result = ((Vala.DataType) result).type_symbol;
+            else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
+                result = ((Vala.UsingDirective) result).namespace_symbol;
 
             // ignore lambda expressions and non-symbols
             if (!(result is Vala.Symbol) ||

--- a/src/util.vala
+++ b/src/util.vala
@@ -314,50 +314,6 @@ namespace Vls.Util {
     }
 
     /**
-     * Find a symbol in `context` matching `sym` or NULL
-     */
-    public Vala.Symbol? find_matching_symbol (Vala.CodeContext context, Vala.Symbol sym) {
-        var symbols = new GLib.Queue<Vala.Symbol> ();
-        Vala.Symbol? matching_sym = null;
-
-        // walk up the symbol hierarchy to the root
-        for (Vala.Symbol? current_sym = sym;
-             current_sym != null && current_sym.name != null && current_sym.to_string () != "(root namespace)";
-             current_sym = current_sym.parent_symbol) {
-            symbols.push_head (current_sym);
-        }
-
-        matching_sym = context.root.scope.lookup (symbols.pop_head ().name);
-        while (!symbols.is_empty () && matching_sym != null) {
-            var parent_sym = matching_sym;
-            var symtab = parent_sym.scope.get_symbol_table ();
-            if (symtab != null) {
-                var current_sym = symbols.pop_head ();
-                matching_sym = symtab[current_sym.name];
-                string? gir_name = null;
-                // look for the GIR version of current_sym instead
-                if (matching_sym == null && (gir_name = current_sym.get_attribute_string ("GIR", "name")) != null) {
-                    matching_sym = symtab[gir_name];
-                    if (matching_sym != null && matching_sym.source_reference.file.file_type != Vala.SourceFileType.PACKAGE)
-                        matching_sym = null;
-                }
-            } else {
-                // workaround: "GLib" namespace may be empty when dealing with GLib-2.0.gir (instead, "G" namespace will be populated)
-                if (matching_sym.name == "GLib") {
-                    matching_sym = context.root.scope.lookup ("G");
-                } else 
-                    matching_sym = null;
-            }
-        }
-
-        if (!symbols.is_empty ())
-            return null;
-
-        return matching_sym;
-    }
-
-
-    /**
      * (stolen from VersionAttribute.cmp_versions in `vala/valaversionattribute.vala`)
      * A simple version comparison function.
      *
@@ -400,5 +356,24 @@ namespace Vls.Util {
         }
 
         return 0;
+    }
+
+    /**
+     * Counts the number of occurrences of @character in @str
+     *
+     * @param str           the string to search
+     * @param character     the character to search for
+     * @param last_char_pos the position of the last occurrence of @character in @str
+     */
+    public uint count_chars_in_string (string str, char character, out int last_char_pos = null) {
+        uint count = 0;
+        last_char_pos = -1;
+        for (int i = 0; i < str.length; i++) {
+            if (str[i] == character) {
+                count++;
+                last_char_pos = i;
+            }
+        }
+        return count;
     }
 }


### PR DESCRIPTION
Implement the `textDocument/rename` method of the protocol. Other changes are made to VLS to improve analysis of references to symbols.