### PR TITLE
Add manpage

### DIFF
--- a/data/man/vala-language-server.1.scd
+++ b/data/man/vala-language-server.1.scd
@@ -1,0 +1,29 @@
+vala-language-server(1)
+
+# NAME
+
+vala-language-server - Code Intelligence for Vala
+
+# SYNOPSIS
+
+*vala-language-server*
+
+# DESCRIPTION
+
+vala-language-server is a language server protocol implementation for Vala.
+It enables features like auto complete, go to defition or documentation
+on hover for IDEs and text editors for the Vala programming language.
+
+# ENVIRONMENT
+
+Users may set the *G_MESSAGES_DEBUG=all* environment variable when launching
+vala-language-server to enable debugging output.
+
+# BUGS
+
+Please file bugs at https://github.com/benwaffle/vala-language-server
+
+# AUTHOR
+
+Ben Iofel <ben@iofel.me>++
+Princeton Ferro <princetonferro@gmail.com>

--- a/data/man/vala-language-server.1.scd
+++ b/data/man/vala-language-server.1.scd
@@ -2,7 +2,7 @@ vala-language-server(1)
 
 # NAME
 
-vala-language-server - Code Intelligence for Vala
+vala-language-server - Code Intelligence for Vala and Genie.
 
 # SYNOPSIS
 
@@ -10,9 +10,10 @@ vala-language-server - Code Intelligence for Vala
 
 # DESCRIPTION
 
-vala-language-server is a language server protocol implementation for Vala.
-It enables features like auto complete, go to defition or documentation
-on hover for IDEs and text editors for the Vala programming language.
+vala-language-server is a language server protocol implementation for Vala
+and Genie. It enables features like auto-complete, go-to-definition,
+hover, symbol documentation, and more for editors/plugins supporting Vala
+and the Language Server Protocol.
 
 # ENVIRONMENT
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,28 @@
+scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_option('man_pages'))
+if scdoc.found()
+    scdoc_prog = find_program(scdoc.get_pkgconfig_variable('scdoc'), native: true)
+    sh = find_program('sh', native: true)
+    mandir = get_option('mandir')
+    man_files = [
+        'man/vala-language-server.1.scd',
+    ]
+    foreach filename : man_files
+        topic = filename.split('.')[-3].split('/')[-1]
+        if topic.contains('_')
+            topic = topic.split('_')[0] + '.' + topic.split('_')[1]
+        endif
+        section = filename.split('.')[-2]
+        output = '@0@.@1@'.format(topic, section)
+
+        custom_target(
+            output,
+            input: filename,
+            output: output,
+            command: [
+                sh, '-c', '@0@ < @INPUT@ > @1@'.format(scdoc_prog.path(), meson.current_build_dir() / output)
+            ],
+            install: true,
+            install_dir: '@0@/man@1@'.format(mandir, section)
+        )
+    endforeach
+endif

--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,7 @@ else
     deps += dependency('gio-unix-2.0')
 endif
 
+subdir('data')
 subdir('plugins/gnome-builder')
 subdir('src')
 subdir('test')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,4 @@ option('parse_system_girs', type: 'boolean', value: true, description: 'Parse sy
 option('active_parameter', type: 'boolean', value: false, description: 'Support activeParameter in signatureHelp')
 option('debug_mem', type: 'boolean', value: false, description: 'Debug memory usage')
 option('builder_abi', type: 'string', value: '3.36', description: 'Builder ABI version')
+option('man_pages', type: 'feature', value: 'auto', description: 'Generate and install man pages.')


### PR DESCRIPTION
This generates a manpage via scdoc, which has a markdown-like
syntax, has no additional dependencies and is available in
many distros already.

fixes #63