### PR TITLE
Fix brokenness with meson custom targets

### DIFF
--- a/src/projects/buildtask.vala
+++ b/src/projects/buildtask.vala
@@ -206,26 +206,9 @@ class Vls.BuildTask : BuildTarget {
             }
         }
 
-        var temp_outputs = new ArrayList<File> (Util.file_equal);
         foreach (string? output_filename in target_output_files) {
             if (output_filename != null)
-                temp_outputs.add (File.new_for_commandline_arg_and_cwd (output_filename, build_dir));
-        }
-
-        if (language == "c") {
-            output.add_all (temp_outputs);
-        } else {
-            // other kinds of targets may transform *.in files to their outputs, so
-            // we look for all files in target_output_files that correspond to these inputs
-            foreach (File input_file in input) {
-                string input_path = (!) input_file.get_path ();
-                if (input_path.has_suffix (".in")) {
-                    foreach (File output_file in temp_outputs) {
-                        if (input_path == output_file.get_path () + ".in")
-                            output.add (output_file);
-                    }
-                }
-            }
+                output.add (File.new_for_commandline_arg_and_cwd (output_filename, build_dir));
         }
     }
 

--- a/src/projects/mesonproject.vala
+++ b/src/projects/mesonproject.vala
@@ -500,12 +500,23 @@ class Vls.MesonProject : Project {
                 BuildTarget? previous_target = null;
                 if (swap_with_previous_target)
                     previous_target = build_targets.remove_at (build_targets.size - 1);
+                string? cmd_basename = first_source.compiler.length > 0 ? Path.get_basename (first_source.compiler[0]) : null;
+                string[] compiler;
+                string[] parameters;
+                if (cmd_basename == "vapigen" || cmd_basename == "glib-mkenums" || cmd_basename == "g-ir-scanner") {
+                    compiler = first_source.compiler;
+                    parameters = first_source.parameters;
+                } else {
+                    target_build_dir = build_dir;
+                    compiler = {"meson", "compile", meson_target_info.name};
+                    parameters = {};
+                }
                 build_targets.add (new BuildTask (target_build_dir,
                                                   meson_target_info.name, 
                                                   meson_target_info.id, 
                                                   elem_idx + (swap_with_previous_target ? -1 : 0),
-                                                  first_source.compiler, 
-                                                  first_source.parameters, 
+                                                  compiler, 
+                                                  parameters, 
                                                   first_source.sources,
                                                   first_source.generated_sources,
                                                   meson_target_info.filename,


### PR DESCRIPTION
I was trying to use the language server with a project that uses [vala-dbus-binding-tool](https://github.com/freesmartphone/vala-dbus-binding-tool) and I noticed it was failing to build the generated targets. The way vala-language-server replaces special args is not quite accurate to the way meson does it, and some custom targets are skipped entirely; hopefully this PR should fix both. This PR is useful by itself but there is an additional problem with meson where it doesn't export custom target dependencies correctly. That is fixed by this other upstream change to meson I submitted: https://github.com/mesonbuild/meson/pull/8674

I didn't do any substantial testing with autotools projects so probably someone should check to see if this PR accidentally broke something there.